### PR TITLE
fix: fall back to club avatar for event covers instead of broken-image icon

### DIFF
--- a/server/web/models/models.go
+++ b/server/web/models/models.go
@@ -96,6 +96,7 @@ type Event struct {
 	Name                         string
 	URL                          string
 	CoverPhotoURL                string
+	ClubAvatarURL                string
 	Details                      string
 	Time                         time.Time
 	EndTime                      time.Time

--- a/server/web/models/models.go
+++ b/server/web/models/models.go
@@ -58,12 +58,13 @@ type ClubWithEvents struct {
 	Pinned bool
 }
 
-func NewEvent(event database.Event, iconSize int) Event {
+func NewEvent(event database.Event, iconSize int, clubAvatarURL string) Event {
 	return Event{
 		ID:            event.ID,
 		Name:          event.Name,
 		URL:           fmt.Sprintf("/tracker/event/%s", event.ID),
 		CoverPhotoURL: ImageURL(event.CoverPhotoURL, iconSize),
+		ClubAvatarURL: clubAvatarURL,
 		Creator: Member{
 			ID: event.CreatorID,
 		},
@@ -78,15 +79,15 @@ func NewEvent(event database.Event, iconSize int) Event {
 	}
 }
 
-func NewEventWithCheckIns(event database.EventWithCheckIns, iconSize int) Event {
-	e := NewEvent(event.Event, iconSize)
+func NewEventWithCheckIns(event database.EventWithCheckIns, iconSize int, clubAvatarURL string) Event {
+	e := NewEvent(event.Event, iconSize, clubAvatarURL)
 	e.Accepted = event.Accepted
 	e.CheckIns = event.CheckIns
 	return e
 }
 
-func NewEventWithCreator(event database.EventWithCreator) Event {
-	e := NewEvent(event.Event, 48)
+func NewEventWithCreator(event database.EventWithCreator, clubAvatarURL string) Event {
+	e := NewEvent(event.Event, 48, clubAvatarURL)
 	e.Creator = NewMember(event.Member, event.Event.ClubID, 32)
 	return e
 }
@@ -228,15 +229,17 @@ func GroupEventsByClub(rows []database.EventWithClub, iconSize int) []ClubMember
 	index := make(map[string]int)
 
 	for _, row := range rows {
+		clubAvatarURL := ImageURL(row.Club.AvatarURL, iconSize)
+
 		if i, ok := index[row.Club.ID]; ok {
-			groups[i].Events = append(groups[i].Events, NewEvent(row.Event, iconSize))
+			groups[i].Events = append(groups[i].Events, NewEvent(row.Event, iconSize, clubAvatarURL))
 			continue
 		}
 
 		index[row.Club.ID] = len(groups)
 		groups = append(groups, ClubMemberEvents{
 			Club:   NewClub(database.ClubWithCreator{Club: row.Club}),
-			Events: []Event{NewEvent(row.Event, iconSize)},
+			Events: []Event{NewEvent(row.Event, iconSize, clubAvatarURL)},
 		})
 	}
 
@@ -259,9 +262,9 @@ type TopMember struct {
 	CheckInRate float64
 }
 
-func NewTopEvent(event database.EventWithCheckIns, iconSize int) TopEvent {
+func NewTopEvent(event database.EventWithCheckIns, iconSize int, clubAvatarURL string) TopEvent {
 	return TopEvent{
-		Event:       NewEvent(event.Event, iconSize),
+		Event:       NewEvent(event.Event, iconSize, clubAvatarURL),
 		Accepted:    event.Accepted,
 		CheckIns:    event.CheckIns,
 		CheckInRate: CalcCheckInRate(event.Accepted, event.CheckIns),

--- a/server/web/templates/templates.gohtml
+++ b/server/web/templates/templates.gohtml
@@ -31,6 +31,16 @@
     {{ if . }}✅️{{ else }}❌{{ end }}
 {{ end}}
 
+{{ define "event_cover" }}
+    {{ if .CoverPhotoURL }}
+        <img src="{{ .CoverPhotoURL }}">
+    {{ else if .ClubAvatarURL }}
+        <img src="{{ .ClubAvatarURL }}">
+    {{ else }}
+        <img src="/static/default.png">
+    {{ end }}
+{{ end }}
+
 {{ define "community_ambassador_icon" }}
     <img src="/static/community-ambassador.png" class="icon-32 ca-icon" alt="Community Ambassador" title="Community Ambassador">
 {{ end }}

--- a/server/web/tracker/club.go
+++ b/server/web/tracker/club.go
@@ -44,8 +44,7 @@ func (h *handler) TrackerClub(w http.ResponseWriter, r *http.Request) {
 
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEventWithCheckIns(event, 32)
-		trackerEvents[i].ClubAvatarURL = clubModel.AvatarURL
+		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, clubModel.AvatarURL)
 	}
 
 	session := auth.GetSession(r)

--- a/server/web/tracker/club.go
+++ b/server/web/tracker/club.go
@@ -41,10 +41,11 @@ func (h *handler) TrackerClub(w http.ResponseWriter, r *http.Request) {
 	}
 
 	clubModel := models.NewClub(*club)
+	eventClubAvatarURL := models.ImageURL(club.Club.AvatarURL, 32)
 
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, clubModel.AvatarURL)
+		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, eventClubAvatarURL)
 	}
 
 	session := auth.GetSession(r)

--- a/server/web/tracker/club.go
+++ b/server/web/tracker/club.go
@@ -40,9 +40,12 @@ func (h *handler) TrackerClub(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clubModel := models.NewClub(*club)
+
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
 		trackerEvents[i] = models.NewEventWithCheckIns(event, 32)
+		trackerEvents[i].ClubAvatarURL = clubModel.AvatarURL
 	}
 
 	session := auth.GetSession(r)
@@ -55,7 +58,7 @@ func (h *handler) TrackerClub(w http.ResponseWriter, r *http.Request) {
 	pinned := slices.Contains(pinnedClubs, clubID)
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club.gohtml", TrackerClubVars{
-		Club:   models.NewClub(*club),
+		Club:   clubModel,
 		Events: trackerEvents,
 		Pinned: pinned,
 	}); err != nil {

--- a/server/web/tracker/club_event.go
+++ b/server/web/tracker/club_event.go
@@ -67,8 +67,7 @@ func (h *handler) TrackerClubEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	clubModel := models.NewClub(*club)
-	eventModel := models.NewEventWithCreator(*event)
-	eventModel.ClubAvatarURL = clubModel.AvatarURL
+	eventModel := models.NewEventWithCreator(*event, clubModel.AvatarURL)
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_event.gohtml", TrackerClubEventVars{
 		Event:            eventModel,

--- a/server/web/tracker/club_event.go
+++ b/server/web/tracker/club_event.go
@@ -66,9 +66,13 @@ func (h *handler) TrackerClubEvent(w http.ResponseWriter, r *http.Request) {
 		acceptedTrackerMembers[i] = models.NewMember(member, event.ClubID, 32)
 	}
 
+	clubModel := models.NewClub(*club)
+	eventModel := models.NewEventWithCreator(*event)
+	eventModel.ClubAvatarURL = clubModel.AvatarURL
+
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_event.gohtml", TrackerClubEventVars{
-		Event:            models.NewEventWithCreator(*event),
-		Club:             models.NewClub(*club),
+		Event:            eventModel,
+		Club:             clubModel,
 		CheckedInMembers: checkedInTrackerMembers,
 		AcceptedMembers:  acceptedTrackerMembers,
 	}); err != nil {

--- a/server/web/tracker/club_events.go
+++ b/server/web/tracker/club_events.go
@@ -59,9 +59,11 @@ func (h *handler) TrackerClubEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clubModel := models.NewClub(*club)
+
 	trackerEvents := make([]models.TopEvent, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewTopEvent(event, 32)
+		trackerEvents[i] = models.NewTopEvent(event, 32, clubModel.AvatarURL)
 	}
 
 	totalAccepted, totalCheckIns, err := h.DB.GetClubTotalCheckInsAccepted(ctx, clubID, from, to, onlyCAEvents, eventCreator)
@@ -73,7 +75,7 @@ func (h *handler) TrackerClubEvents(w http.ResponseWriter, r *http.Request) {
 	totalCheckInRate := models.CalcCheckInRate(totalAccepted, totalCheckIns)
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_events.gohtml", TrackerClubEventsVars{
-		Club: models.NewClub(*club),
+		Club: clubModel,
 		EventsFilter: EventsFilter{
 			FilterURL:            r.URL.Path,
 			From:                 from,

--- a/server/web/tracker/club_events.go
+++ b/server/web/tracker/club_events.go
@@ -60,10 +60,11 @@ func (h *handler) TrackerClubEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	clubModel := models.NewClub(*club)
+	eventClubAvatarURL := models.ImageURL(club.Club.AvatarURL, 32)
 
 	trackerEvents := make([]models.TopEvent, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewTopEvent(event, 32, clubModel.AvatarURL)
+		trackerEvents[i] = models.NewTopEvent(event, 32, eventClubAvatarURL)
 	}
 
 	totalAccepted, totalCheckIns, err := h.DB.GetClubTotalCheckInsAccepted(ctx, clubID, from, to, onlyCAEvents, eventCreator)

--- a/server/web/tracker/club_export.go
+++ b/server/web/tracker/club_export.go
@@ -51,9 +51,11 @@ func (h *handler) renderTrackerClubExport(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	clubModel := models.NewClub(*club)
+
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEventWithCheckIns(event, 32)
+		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, clubModel.AvatarURL)
 	}
 
 	eventCreators, err := h.getEventCreators(ctx, clubID)
@@ -64,7 +66,7 @@ func (h *handler) renderTrackerClubExport(w http.ResponseWriter, r *http.Request
 	}
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_export.gohtml", TrackerClubExportVars{
-		Club: models.NewClub(*club),
+		Club: clubModel,
 		EventsFilter: EventsFilter{
 			FilterURL:            r.URL.Path,
 			From:                 from,

--- a/server/web/tracker/club_export.go
+++ b/server/web/tracker/club_export.go
@@ -52,10 +52,11 @@ func (h *handler) renderTrackerClubExport(w http.ResponseWriter, r *http.Request
 	}
 
 	clubModel := models.NewClub(*club)
+	eventClubAvatarURL := models.ImageURL(club.Club.AvatarURL, 32)
 
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, clubModel.AvatarURL)
+		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, eventClubAvatarURL)
 	}
 
 	eventCreators, err := h.getEventCreators(ctx, clubID)

--- a/server/web/tracker/club_member.go
+++ b/server/web/tracker/club_member.go
@@ -49,10 +49,11 @@ func (h *handler) TrackerClubMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	clubModel := models.NewClub(*club)
+	eventClubAvatarURL := models.ImageURL(club.Club.AvatarURL, 32)
 
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEvent(event, 32, clubModel.AvatarURL)
+		trackerEvents[i] = models.NewEvent(event, 32, eventClubAvatarURL)
 	}
 
 	acceptedEvents, err := h.DB.GetAcceptedClubEventsByMember(ctx, clubID, memberID)
@@ -63,7 +64,7 @@ func (h *handler) TrackerClubMember(w http.ResponseWriter, r *http.Request) {
 	}
 	acceptedTrackerEvents := make([]models.Event, len(acceptedEvents))
 	for i, event := range acceptedEvents {
-		acceptedTrackerEvents[i] = models.NewEvent(event, 32, clubModel.AvatarURL)
+		acceptedTrackerEvents[i] = models.NewEvent(event, 32, eventClubAvatarURL)
 	}
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_member.gohtml", TrackerClubMemberVars{

--- a/server/web/tracker/club_member.go
+++ b/server/web/tracker/club_member.go
@@ -52,8 +52,7 @@ func (h *handler) TrackerClubMember(w http.ResponseWriter, r *http.Request) {
 
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEvent(event, 32)
-		trackerEvents[i].ClubAvatarURL = clubModel.AvatarURL
+		trackerEvents[i] = models.NewEvent(event, 32, clubModel.AvatarURL)
 	}
 
 	acceptedEvents, err := h.DB.GetAcceptedClubEventsByMember(ctx, clubID, memberID)
@@ -64,8 +63,7 @@ func (h *handler) TrackerClubMember(w http.ResponseWriter, r *http.Request) {
 	}
 	acceptedTrackerEvents := make([]models.Event, len(acceptedEvents))
 	for i, event := range acceptedEvents {
-		acceptedTrackerEvents[i] = models.NewEvent(event, 32)
-		acceptedTrackerEvents[i].ClubAvatarURL = clubModel.AvatarURL
+		acceptedTrackerEvents[i] = models.NewEvent(event, 32, clubModel.AvatarURL)
 	}
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_member.gohtml", TrackerClubMemberVars{

--- a/server/web/tracker/club_member.go
+++ b/server/web/tracker/club_member.go
@@ -48,9 +48,12 @@ func (h *handler) TrackerClubMember(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to fetch club events by member: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	clubModel := models.NewClub(*club)
+
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
 		trackerEvents[i] = models.NewEvent(event, 32)
+		trackerEvents[i].ClubAvatarURL = clubModel.AvatarURL
 	}
 
 	acceptedEvents, err := h.DB.GetAcceptedClubEventsByMember(ctx, clubID, memberID)
@@ -62,11 +65,12 @@ func (h *handler) TrackerClubMember(w http.ResponseWriter, r *http.Request) {
 	acceptedTrackerEvents := make([]models.Event, len(acceptedEvents))
 	for i, event := range acceptedEvents {
 		acceptedTrackerEvents[i] = models.NewEvent(event, 32)
+		acceptedTrackerEvents[i].ClubAvatarURL = clubModel.AvatarURL
 	}
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_member.gohtml", TrackerClubMemberVars{
 		Member:         models.NewMember(*member, clubID, 48),
-		Club:           models.NewClub(*club),
+		Club:           clubModel,
 		Events:         trackerEvents,
 		AcceptedEvents: acceptedTrackerEvents,
 	}); err != nil {

--- a/server/web/tracker/club_raffle.go
+++ b/server/web/tracker/club_raffle.go
@@ -51,10 +51,11 @@ func (h *handler) renderTrackerClubRaffle(w http.ResponseWriter, r *http.Request
 	}
 
 	clubModel := models.NewClub(*club)
+	eventClubAvatarURL := models.ImageURL(club.Club.AvatarURL, 32)
 
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, clubModel.AvatarURL)
+		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, eventClubAvatarURL)
 	}
 
 	eventCreators, err := h.getEventCreators(ctx, clubID)

--- a/server/web/tracker/club_raffle.go
+++ b/server/web/tracker/club_raffle.go
@@ -50,9 +50,11 @@ func (h *handler) renderTrackerClubRaffle(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	clubModel := models.NewClub(*club)
+
 	trackerEvents := make([]models.Event, len(events))
 	for i, event := range events {
-		trackerEvents[i] = models.NewEventWithCheckIns(event, 32)
+		trackerEvents[i] = models.NewEventWithCheckIns(event, 32, clubModel.AvatarURL)
 	}
 
 	eventCreators, err := h.getEventCreators(ctx, clubID)
@@ -63,7 +65,7 @@ func (h *handler) renderTrackerClubRaffle(w http.ResponseWriter, r *http.Request
 	}
 
 	if err = h.Templates().ExecuteTemplate(w, "tracker_club_raffle.gohtml", TrackerClubRaffleVars{
-		Club: models.NewClub(*club),
+		Club: clubModel,
 		EventsFilter: EventsFilter{
 			FilterURL:            r.URL.Path,
 			From:                 from,

--- a/server/web/tracker/event.go
+++ b/server/web/tracker/event.go
@@ -80,12 +80,15 @@ func (h *handler) GetEvent(w http.ResponseWriter, r *http.Request) {
 		clubImportedAt = club.Club.ImportedAt
 	}
 
+	clubAvatarURL := models.ImageURL(event.Club.AvatarURL, 32)
+
 	if err = h.Templates().ExecuteTemplate(w, "event_details.gohtml", TrackerEventCheckIns{
 		Event: models.Event{
 			ID:                           event.ID,
 			Name:                         event.Name,
 			URL:                          fmt.Sprintf("/tracker/event/%s", event.ID),
 			CoverPhotoURL:                models.ImageURL(event.CoverPhotoURL, 48),
+			ClubAvatarURL:                clubAvatarURL,
 			Details:                      event.Details,
 			Time:                         event.EventTime,
 			EndTime:                      event.EventEndTime,
@@ -98,7 +101,7 @@ func (h *handler) GetEvent(w http.ResponseWriter, r *http.Request) {
 		Club: models.Club{
 			ID:                           event.ClubID,
 			Name:                         event.Club.Name,
-			AvatarURL:                    models.ImageURL(event.Club.AvatarURL, 32),
+			AvatarURL:                    clubAvatarURL,
 			Creator:                      models.NewMemberFromCampfire(event.Club.Creator, event.Club.ID, 32),
 			CreatedByCommunityAmbassador: event.Club.CreatedByCommunityAmbassador,
 			ImportedAt:                   clubImportedAt,

--- a/server/web/tracker/event.go
+++ b/server/web/tracker/event.go
@@ -80,6 +80,7 @@ func (h *handler) GetEvent(w http.ResponseWriter, r *http.Request) {
 		clubImportedAt = club.Club.ImportedAt
 	}
 
+	eventClubAvatarURL := models.ImageURL(event.Club.AvatarURL, 48)
 	clubAvatarURL := models.ImageURL(event.Club.AvatarURL, 32)
 
 	if err = h.Templates().ExecuteTemplate(w, "event_details.gohtml", TrackerEventCheckIns{
@@ -88,7 +89,7 @@ func (h *handler) GetEvent(w http.ResponseWriter, r *http.Request) {
 			Name:                         event.Name,
 			URL:                          fmt.Sprintf("/tracker/event/%s", event.ID),
 			CoverPhotoURL:                models.ImageURL(event.CoverPhotoURL, 48),
-			ClubAvatarURL:                clubAvatarURL,
+			ClubAvatarURL:                eventClubAvatarURL,
 			Details:                      event.Details,
 			Time:                         event.EventTime,
 			EndTime:                      event.EventEndTime,

--- a/server/web/tracker/raffle.go
+++ b/server/web/tracker/raffle.go
@@ -266,7 +266,7 @@ func (h *handler) GetRaffle(w http.ResponseWriter, r *http.Request) {
 	}
 	renderEvents := make([]models.Event, 0, len(raffleEvents))
 	for _, event := range raffleEvents {
-		renderEvents = append(renderEvents, models.NewEvent(event, 32))
+		renderEvents = append(renderEvents, models.NewEvent(event, 32, ""))
 	}
 
 	session := auth.GetSession(r)

--- a/server/web/tracker/raffle_events.go
+++ b/server/web/tracker/raffle_events.go
@@ -235,6 +235,7 @@ func (h *handler) renderClubAddRaffleEvents(w http.ResponseWriter, r *http.Reque
 	}
 
 	clubModel := models.NewClub(*club)
+	eventClubAvatarURL := models.ImageURL(club.Club.AvatarURL, 32)
 
 	existingSet := make(map[string]struct{}, len(existingEventIDs))
 	for _, id := range existingEventIDs {
@@ -246,7 +247,7 @@ func (h *handler) renderClubAddRaffleEvents(w http.ResponseWriter, r *http.Reque
 		if _, exists := existingSet[event.Event.ID]; exists {
 			continue
 		}
-		availableEvents = append(availableEvents, models.NewEventWithCheckIns(event, 32, clubModel.AvatarURL))
+		availableEvents = append(availableEvents, models.NewEventWithCheckIns(event, 32, eventClubAvatarURL))
 	}
 
 	eventCreators, err := h.getEventCreators(ctx, clubID)

--- a/server/web/tracker/templates/event_details.gohtml
+++ b/server/web/tracker/templates/event_details.gohtml
@@ -3,9 +3,7 @@
     <div class="container-header">
         {{ template "back_button" "/event" }}
         <h1>
-            {{ if .CoverPhotoURL }}
-                <img src="{{ .CoverPhotoURL }}">
-            {{ end }}
+            {{ template "event_cover" . }}
             {{ .Name }}
         </h1>
     </div>

--- a/server/web/tracker/templates/tracker_club.gohtml
+++ b/server/web/tracker/templates/tracker_club.gohtml
@@ -71,11 +71,7 @@
         <ul class="list">
             {{ range $event := .Events }}
                 <li class="list-item">
-                    {{ if $event.CoverPhotoURL }}
-                        <img src="{{ $event.CoverPhotoURL }}">
-                    {{ else }}
-                        <img src="/static/default.png">
-                    {{ end }}
+                    {{ template "event_cover" $event }}
                     <a href="{{ $event.URL }}" hx-boost="true">
                         {{ $event.Name }} ({{ $event.CheckIns }})
                     </a>{{ template "community_ambassador_flag" $event.CreatedByCommunityAmbassador }}

--- a/server/web/tracker/templates/tracker_club_event.gohtml
+++ b/server/web/tracker/templates/tracker_club_event.gohtml
@@ -3,9 +3,7 @@
     <div class="container-header">
         {{ template "back_button" .Club.URL }}
         <h1>
-            {{ if .CoverPhotoURL }}
-                <img src="{{ .CoverPhotoURL }}">
-            {{ end }}
+            {{ template "event_cover" . }}
             {{ .Name }}
             {{ template "community_ambassador_flag" .CreatedByCommunityAmbassador }}
         </h1>

--- a/server/web/tracker/templates/tracker_club_member.gohtml
+++ b/server/web/tracker/templates/tracker_club_member.gohtml
@@ -32,11 +32,7 @@
         <ul class="list">
             {{ range $event := .Events }}
                 <li class="list-item">
-                    {{ if $event.CoverPhotoURL }}
-                        <img src="{{ $event.CoverPhotoURL }}">
-                    {{ else }}
-                        <img src="/static/default.png">
-                    {{ end }}
+                    {{ template "event_cover" $event }}
                     <a href="{{ $event.URL }}" title="{{ .ID }}" hx-boost="true">
                         {{ $event.Name }}
                     </a>{{ template "community_ambassador_flag" $event.CreatedByCommunityAmbassador }}
@@ -54,11 +50,7 @@
         <ul class="list">
             {{ range $event := .AcceptedEvents }}
                 <li class="list-item">
-                    {{ if $event.CoverPhotoURL }}
-                        <img src="{{ $event.CoverPhotoURL }}">
-                    {{ else }}
-                        <img src="/static/default.png">
-                    {{ end }}
+                    {{ template "event_cover" $event }}
                     <a href="{{ $event.URL }}" title="{{ .ID }}" hx-boost="true">
                         {{ $event.Name }}
                     </a>{{ template "community_ambassador_flag" $event.CreatedByCommunityAmbassador }}


### PR DESCRIPTION
## Summary
- Events without a cover photo currently fall back to a generic "broken image" placeholder icon (`/static/default.png`) across the club event list, member check-in/accepted lists, and both event detail pages.
- Campfire's own app falls back to the club's logo in that situation instead. This PR does the same, adding a small `event_cover` template partial and a `ClubAvatarURL` field on the presentation-layer `Event` model (no DB/schema changes).

## Test plan
- [x] `go build ./...`
- [x] Verified template parsing (`ParseGlob` over all `.gohtml` files)
- [x] Ran locally against a real imported club: events without a cover photo now show the club avatar instead of the broken-image icon, in all 4 affected views (club event list, member check-ins/accepted, single club-event page, public event page)
- [x] Events that do have a cover photo are unaffected